### PR TITLE
Change calculation to better position subtitle.

### DIFF
--- a/lib/SVG/Graph/Graph.rb
+++ b/lib/SVG/Graph/Graph.rb
@@ -661,7 +661,7 @@ module SVG
 
         if show_graph_subtitle
           y_subtitle = show_graph_title ? 
-            title_font_size + 10 :
+            title_font_size + subtitle_font_size + 5 :
             subtitle_font_size
           @root.add_element("text", {
             "x" => (width / 2).to_s,


### PR DESCRIPTION
Add subtitle font size to calculation for positioning of subtitle when there's both a title and a subtitle. This helps keep the two from overlapping.
