### PR TITLE
Fix regexp in test_plot.rb for Ruby1.8

### DIFF
--- a/test/test_plot.rb
+++ b/test/test_plot.rb
@@ -245,8 +245,8 @@ class TestSvgGraphPlot < Test::Unit::TestCase
     })
 
     out=graph.burn()
-    assert_match(/circle .* r='10'/, out)
-    assert_match(/circle .* onmouseover=.*/, out)
+    assert_match(/circle .*r='10'/, out)
+    assert_match(/circle .*onmouseover=.*/, out)
     
   end
   def test_popup_radius_is_overridable
@@ -275,8 +275,8 @@ class TestSvgGraphPlot < Test::Unit::TestCase
     })
 
     out=graph.burn()
-    assert_match(/circle .* r='1.23'/, out)
-    assert_match(/circle .* onmouseover=.*/, out)
+    assert_match(/circle .*r='1.23'/, out)
+    assert_match(/circle .*onmouseover=.*/, out)
     
   end
 end


### PR DESCRIPTION
Hi!

The ordering of parameters with Ruby1.8 is not deterministic, because it
comes from a Hash. The previous regexps required two spaces between
'circle' and the other keyword, which does not work if the keyword comes
just after 'circle'.

This problem caused a build failure for the Debian package:
http://bugs.debian.org/713168

Removing one space in these regexp solves the problem.

Cheers,

Cédric
