### PR TITLE
Remove warnings

### DIFF
--- a/lib/SVG/Graph/Graph.rb
+++ b/lib/SVG/Graph/Graph.rb
@@ -1,14 +1,13 @@
-begin
-  require 'zlib'
-  @@__have_zlib = true
-rescue
-  @@__have_zlib = false
-end
-
 require 'rexml/document'
 
 module SVG
   module Graph
+    begin
+      require 'zlib'
+      @@__have_zlib = true
+    rescue
+      @@__have_zlib = false
+    end
 
     # === Base object for generating SVG Graphs
     # 
@@ -142,7 +141,6 @@ module SVG
           :x_label_font_size    =>12,
           :y_label_font_size    =>12,
           :x_title_font_size    =>14,
-          :y_label_font_size    =>12,
           :y_title_font_size    =>14,
           :key_font_size        =>10,
           


### PR DESCRIPTION
The following warning were listed in ruby 2.2.3 after a require 'SVG/Graph/Plot' :
- l143: duplicated key at line 145 ignored: :y_label_font_size
- l3: class variable access from toplevel
