### PR TITLE
Correct spelling mistakes

### DIFF
--- a/README.txt
+++ b/README.txt
@@ -18,7 +18,7 @@ This software is available under the Ruby license[LICENSE.txt]
 
 This is a  revision of the [SVG::Graph library](http://www.germane-software.com/software/SVG/SVG::Graph/) by Sean Russell with touch-ups to make it run on Ruby 1.9.x and be gem-installable. See History.txt for other changes
 
-SVG:::Graph is a pure Ruby library for generating charts, which are a type of graph where the values of one axis are not scalar. SVG::Graph has a verry similar API to the Perl library SVG::TT::Graph, and the resulting charts also look the same. This isn't surprising, because SVG::Graph started as a loose port of SVG::TT::Graph, although the internal code no longer resembles the Perl original at all.
+SVG:::Graph is a pure Ruby library for generating charts, which are a type of graph where the values of one axis are not scalar. SVG::Graph has a very similar API to the Perl library SVG::TT::Graph, and the resulting charts also look the same. This isn't surprising, because SVG::Graph started as a loose port of SVG::TT::Graph, although the internal code no longer resembles the Perl original at all.
 
 == FEATURES
 

--- a/dist.xml.in
+++ b/dist.xml.in
@@ -20,7 +20,7 @@
 	<description>
 		<p>
       SVG:::Graph is a pure Ruby library for generating charts, which are a type of graph 
-      where the values of one axis are not scalar.  SVG::Graph has a verry similar API
+      where the values of one axis are not scalar.  SVG::Graph has a very similar API
       to the Perl library SVG::TT::Graph, and the resulting charts also look the same.
 		</p>
 

--- a/index.xml
+++ b/index.xml
@@ -23,7 +23,7 @@
 
     <para>SVG:::Graph is a pure Ruby library for generating charts, which are
     a type of graph where the values of one axis are not scalar. SVG::Graph
-    has a verry similar API to the Perl library SVG::TT::Graph, and the
+    has a very similar API to the Perl library SVG::TT::Graph, and the
     resulting charts also look the same. This isn't surprising, because
     SVG::Graph started as a loose port of SVG::TT::Graph, although the
     internal code no longer resembles the Perl original at all.</para>
@@ -117,7 +117,7 @@
     <para>The SVG::TT:Graph package is just fine. It lacked a couple of
     features that I wanted, and it was in Perl<footnote>
         <para>Perl is from Hell. The language is bad enough, but working with
-        the package system -- CPAN, etc. -- is an exercize in masochism. I'd
+        the package system -- CPAN, etc. -- is an exercise in masochism. I'd
         rather chew on glass.</para>
       </footnote>, so I re-implemented it.</para>
 
@@ -134,7 +134,7 @@
 
     <para>In version 0.2.0 I completely refactored the code to make it more
     modular. As a result, the core Graph class contains most of the graph
-    drawing primatives, and the specializations (Bar, BarHorizontal, Line,
+    drawing primitives, and the specializations (Bar, BarHorizontal, Line,
     Pie, etc.) only draw the plot itself. This results in many fewer lines of
     code, and that code is more robust. SVG::TT::Graph re-implemented most of
     the code for every plot type, whereas SVG::Graph reuses most of the
@@ -152,7 +152,7 @@
     style (you can't use your own styles with CSS disabled). However, a number
     of SVG renderers do not support or do not fully support CSS in SVG (KSVG
     in Konqueror and librsvg, for instance). Adobe and Batik both support CSS,
-    so if those are your targets, you can use CSS. For maximum compatability,
+    so if those are your targets, you can use CSS. For maximum compatibility,
     disable CSS with the :no_css attriibute.</para>
 
     <para>The currently supported graph types are:</para>
@@ -189,7 +189,7 @@
   </sect1>
 
   <sect1>
-    <title>Dependancies</title>
+    <title>Dependencies</title>
 
     <para>REXML 3.0+, or Ruby 1.8+. If you want to use the SVG compression
     feature, which generates zlib compressed SVGs, you must also have the Ruby

--- a/lib/SVG/Graph/Bar.rb
+++ b/lib/SVG/Graph/Bar.rb
@@ -37,7 +37,7 @@ module SVG
     #
     # = Notes
     #
-    # The default stylesheet handles upto 12 data sets, if you
+    # The default stylesheet handles up to 12 data sets, if you
     # use more you must create your own stylesheet and add the
     # additional settings for the extra data sets. You will know
     # if you go over 12 data sets as they will have no style and

--- a/lib/SVG/Graph/Graph.rb
+++ b/lib/SVG/Graph/Graph.rb
@@ -233,7 +233,7 @@ module SVG
       #   scales to fix the space.
       attr_accessor :width
       #   Set the path to an external stylesheet, set to '' if
-      #   you want to revert back to using the defaut internal version.
+      #   you want to revert back to using the default internal version.
       #
       #   To create an external stylesheet create a graph using the
       #   default internal version and copy the stylesheet section to
@@ -847,7 +847,7 @@ module SVG
         @root << Comment.new( " "+"\\"*66 )
         @root << Comment.new( " Created with SVG::Graph " )
         @root << Comment.new( " SVG::Graph by Sean E. Russell " )
-        @root << Comment.new( " Losely based on SVG::TT::Graph for Perl by"+
+        @root << Comment.new( " Loosely based on SVG::TT::Graph for Perl by"+
         " Leo Lapworth & Stephan Morgan " )
         @root << Comment.new( " "+"/"*66 )
 

--- a/lib/SVG/Graph/Line.rb
+++ b/lib/SVG/Graph/Line.rb
@@ -46,7 +46,7 @@ module SVG
     # 
     # = Notes
     # 
-    # The default stylesheet handles upto 10 data sets, if you
+    # The default stylesheet handles up to 10 data sets, if you
     # use more you must create your own stylesheet and add the
     # additional settings for the extra data sets. You will know
     # if you go over 10 data sets as they will have no style and

--- a/lib/SVG/Graph/Plot.rb
+++ b/lib/SVG/Graph/Plot.rb
@@ -59,7 +59,7 @@ module SVG
     # 
     # = Notes
     # 
-    # The default stylesheet handles upto 10 data sets, if you
+    # The default stylesheet handles up to 10 data sets, if you
     # use more you must create your own stylesheet and add the
     # additional settings for the extra data sets. You will know
     # if you go over 10 data sets as they will have no style and

--- a/lib/SVG/Graph/Schedule.rb
+++ b/lib/SVG/Graph/Schedule.rb
@@ -54,7 +54,7 @@ module SVG
     # 
     # = Notes
     # 
-    # The default stylesheet handles upto 10 data sets, if you
+    # The default stylesheet handles up to 10 data sets, if you
     # use more you must create your own stylesheet and add the
     # additional settings for the extra data sets. You will know
     # if you go over 10 data sets as they will have no style and
@@ -141,7 +141,7 @@ module SVG
       # Note that the data must be in time,value pairs, and that the date format
       # may be any date that is parseable by ParseDate.
       # Also note that, in this example, we're mixing scales; the data from d1
-      # will probably not be discernable if both data sets are plotted on the same
+      # will probably not be discernible if both data sets are plotted on the same
       # graph, since d1 is too granular.
       def add_data data
         @data = [] unless @data

--- a/lib/SVG/Graph/TimeSeries.rb
+++ b/lib/SVG/Graph/TimeSeries.rb
@@ -65,7 +65,7 @@ module SVG
     # 
     # = Notes
     # 
-    # The default stylesheet handles upto 10 data sets, if you
+    # The default stylesheet handles up to 10 data sets, if you
     # use more you must create your own stylesheet and add the
     # additional settings for the extra data sets. You will know
     # if you go over 10 data sets as they will have no style and

--- a/svg-graph.gemspec
+++ b/svg-graph.gemspec
@@ -10,7 +10,7 @@ Gem::Specification.new do |s|
   s.required_rubygems_version = Gem::Requirement.new(">= 0") if s.respond_to? :required_rubygems_version=
   s.authors = [%q{Sean Russell}, %q{Claudio Bustos}, %q{Liehann Loots}, %q{Piergiuliano Bossi}]
   s.date = %q{2011-08-05}
-  s.description = %q{Gem version of SVG:::Graph. SVG:::Graph is a pure Ruby library for generating charts, which are a type of graph where the values of one axis are not scalar. SVG::Graph has a verry similar API to the Perl library SVG::TT::Graph, and the resulting charts also look the same. This isn't surprising, because SVG::Graph started as a loose port of SVG::TT::Graph, although the internal code no longer resembles the Perl original at all.
+  s.description = %q{Gem version of SVG:::Graph. SVG:::Graph is a pure Ruby library for generating charts, which are a type of graph where the values of one axis are not scalar. SVG::Graph has a very similar API to the Perl library SVG::TT::Graph, and the resulting charts also look the same. This isn't surprising, because SVG::Graph started as a loose port of SVG::TT::Graph, although the internal code no longer resembles the Perl original at all.
   }
   s.email = [%q{ser_AT_germane-software.com}, %q{clbustos_AT_gmail.com}, %q{liehannl_AT_gmail_DOT_com}, %q{pgbossi_AT_gmail_DOT_com}]
   s.extra_rdoc_files = [


### PR DESCRIPTION
There is another typo in the github repo description. The word 'verry' should be written as 'very'.